### PR TITLE
指定したランク数が検出されたクラスタ数よりも少ない場合に異常終了しない

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,5 @@ uploads/*.csv
 *.sqlite3
 # mediumディレクトリとそのサブディレクトリの.csvファイルはgit管理しない
 medium/**/*.csv
+
+.gitconfig

--- a/domain/clusters.py
+++ b/domain/clusters.py
@@ -19,6 +19,9 @@ class Clusters:
         sizes = [c.size for c in self._clusters]
         unique_sizes = sorted(list(set(sizes)), reverse=True)
         ranked_sizes = {n + 1: size for n, size in enumerate(unique_sizes)}
+        if rank not in ranked_sizes:
+            raise ValueError(f"count of cluster is less than {rank}")
+
         size = ranked_sizes[rank]
 
         size_features = {c.size: [] for c in self._clusters}

--- a/domain/clusters.py
+++ b/domain/clusters.py
@@ -20,7 +20,7 @@ class Clusters:
         unique_sizes = sorted(list(set(sizes)), reverse=True)
         ranked_sizes = {n + 1: size for n, size in enumerate(unique_sizes)}
         if rank not in ranked_sizes:
-            raise ValueError(f"count of cluster is less than {rank}")
+            raise ValueError(f"Amount of cluster is less than rank: {rank}")
 
         size = ranked_sizes[rank]
 

--- a/ui/cli/network.py
+++ b/ui/cli/network.py
@@ -123,7 +123,12 @@ def clustering(
     )
     container.wire(modules=[sys.modules[__name__]])
     clustering_handler = container.handler()
-    clusters = clustering_handler.run(d)
+
+    try:
+        clusters = clustering_handler.run(d)
+    except ValueError as e:
+        print(f"Error: {e}")
+        sys.exit(1)
 
     # Output
     output = OutputClustering(


### PR DESCRIPTION
### 問題

処理が停止する形で終了していた

### アプローチ

1. エラーが出るケースを補足し、例外を送出する
2. エラーはUI layerで補足する
3. sys.exitで0以外の終了コードを出し終了